### PR TITLE
Stader: Include unstaking. 

### DIFF
--- a/app/export/stader/contract_export_stader_lunax.go
+++ b/app/export/stader/contract_export_stader_lunax.go
@@ -40,6 +40,25 @@ func ExportLunaX(app *terra.TerraApp, bl util.Blacklist) (util.SnapshotBalanceAg
 			Denom:   util.DenomLUNA,
 			Balance: exchangeRate.MulInt(balance).TruncateInt(),
 		})
+
+		// Fetch undelegation requests for this user.
+		undelegations, err := getUserUndelegations(ctx, q, LunaXState, address)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, undelegation := range undelegations {
+			if undelegation.Amount == nil {
+				continue
+			}
+
+			fmt.Println(undelegation)
+
+			snapshot.AppendOrAddBalance(address, util.SnapshotBalance{
+				Denom:   util.DenomLUNA,
+				Balance: exchangeRate.MulInt(*undelegation.Amount).TruncateInt(),
+			})
+		}
 	}
 
 	bl.RegisterAddress(util.DenomLUNA, LunaXState)

--- a/app/export/stader/contract_export_stader_stake_plus.go
+++ b/app/export/stader/contract_export_stader_stake_plus.go
@@ -16,9 +16,9 @@ const (
 )
 
 type UserUndelegationRequest struct {
-	BatchId int      `json:"batch_id"`
-	Shares  sdk.Dec  `json:"shares"`
-	Amount  *sdk.Int `json:"amount"`
+	BatchId int     `json:"batch_id"`
+	Shares  sdk.Dec `json:"shares"`
+	Amount  sdk.Int `json:"amount"`
 }
 
 func contains(s []string, str string) bool {
@@ -99,7 +99,7 @@ func ExportStakePlus(app *terra.TerraApp, bl util.Blacklist) (util.SnapshotBalan
 				})
 
 				// Fetch undelegation requests for this user.
-				undelegations, err := getUserUndelegations(ctx, q, contract, userInfo.UserAddr)
+				undelegations, err := GetUserUndelegations(ctx, q, contract, userInfo.UserAddr)
 				if err != nil {
 					return nil, err
 				}
@@ -108,7 +108,7 @@ func ExportStakePlus(app *terra.TerraApp, bl util.Blacklist) (util.SnapshotBalan
 				for _, undelegation := range undelegations {
 					snapshot.AppendOrAddBalance(userInfo.UserAddr, util.SnapshotBalance{
 						Denom:   util.DenomLUNA,
-						Balance: *undelegation.Amount,
+						Balance: undelegation.Amount,
 					})
 				}
 			}
@@ -120,8 +120,8 @@ func ExportStakePlus(app *terra.TerraApp, bl util.Blacklist) (util.SnapshotBalan
 	return snapshot, nil
 }
 
-// getUserUndelegations fetch all user undelegation requests.
-func getUserUndelegations(ctx context.Context, q wasmtypes.QueryServer, contract string, userAddr string) ([]UserUndelegationRequest, error) {
+// GetUserUndelegations fetch all user undelegation requests.
+func GetUserUndelegations(ctx context.Context, q wasmtypes.QueryServer, contract string, userAddr string) ([]UserUndelegationRequest, error) {
 	undelegationRequests := []UserUndelegationRequest{}
 	var offset = -1
 	for {
@@ -144,7 +144,6 @@ func getUserUndelegations(ctx context.Context, q wasmtypes.QueryServer, contract
 		}
 
 		undelegationRequests = append(undelegationRequests, stakePlusUndelegations...)
-
 		offset = int(stakePlusUndelegations[len(stakePlusUndelegations)-1].BatchId)
 	}
 

--- a/app/export/stader/contract_export_stader_stake_plus.go
+++ b/app/export/stader/contract_export_stader_stake_plus.go
@@ -16,9 +16,9 @@ const (
 )
 
 type UserUndelegationRequest struct {
-	BatchId int     `json:"batch_id"`
-	Shares  sdk.Dec `json:"shares"`
-	Amount  sdk.Int `json:"amount"`
+	BatchId int      `json:"batch_id"`
+	Shares  sdk.Dec  `json:"shares"`
+	Amount  *sdk.Int `json:"amount"`
 }
 
 func contains(s []string, str string) bool {
@@ -108,7 +108,7 @@ func ExportStakePlus(app *terra.TerraApp, bl util.Blacklist) (util.SnapshotBalan
 				for _, undelegation := range undelegations {
 					snapshot.AppendOrAddBalance(userInfo.UserAddr, util.SnapshotBalance{
 						Denom:   util.DenomLUNA,
-						Balance: undelegation.Amount,
+						Balance: *undelegation.Amount,
 					})
 				}
 			}


### PR DESCRIPTION
## Summary of changes

The LunaX Staking contract tracks undelegations separate from the pools, this PR adds them to the total count.

