### PR TITLE
feat: Oneplanet indexing.

### DIFF
--- a/app/export/contract_export.go
+++ b/app/export/contract_export.go
@@ -20,6 +20,7 @@ import (
 	"github.com/terra-money/core/app/export/native"
 	"github.com/terra-money/core/app/export/nebula"
 	"github.com/terra-money/core/app/export/nexus"
+	"github.com/terra-money/core/app/export/oneplanet"
 	"github.com/terra-money/core/app/export/prism"
 	"github.com/terra-money/core/app/export/pylon"
 	"github.com/terra-money/core/app/export/randomearth"
@@ -116,6 +117,7 @@ func ExportContracts(app *terra.TerraApp) []types.Balance {
 	aliceSs := checkWithSs(util.CachedSBA(alice.ExportAlice, "alice", app, bl))
 	kineticSs := checkWithSs(util.CachedSBA(kinetic.ExportKinetic, "kinetic", app, bl))
 	steakSs := checkWithSs(util.CachedSBA(steak.ExportSteak, "steak", app, bl))
+	onePlanetSs := checkWithSs(util.CachedSBA(oneplanet.ExportHoldings, "oneplanet", app, bl))
 	nexusSs, err := nexus.ExportNexus(app, astroportSnapshot, bl)
 	glowSs := checkWithSs(util.CachedSBA(glow.ExportContract, "glow", app, bl))
 	util.SaveToFile(app, nexusSs, "nexus")
@@ -131,7 +133,7 @@ func ExportContracts(app *terra.TerraApp) []types.Balance {
 		randomEarthSs, starfletSs, flokiSs,
 		flokiRefundsSs, nebulaSs, aliceSs, kineticSs,
 		steakSs, nexusSs, marsSs,
-		pylonSs, glowSs,
+		pylonSs, onePlanetSs, glowSs,
 		// anchor
 		aUST,
 		bLunaInCustody,

--- a/app/export/oneplanet/export_oneplanet.go
+++ b/app/export/oneplanet/export_oneplanet.go
@@ -1,0 +1,128 @@
+package oneplanet
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	terra "github.com/terra-money/core/app"
+
+	"github.com/terra-money/core/app/export/util"
+	wasmtypes "github.com/terra-money/core/x/wasm/types"
+)
+
+type Contract struct {
+	Address string
+	Denom   string
+}
+
+var (
+	opUST = Contract{
+		Address: "terra1r27hqy58tmgnv9uykc708wzdlel9n3g0qdm04c",
+		Denom:   util.DenomUST,
+	}
+	opLUNA = Contract{
+		Address: "terra15d2d3pw6ag3tltycmvn2uxfnlwcr86utyl83r6",
+		Denom:   util.DenomLUNA,
+	}
+)
+
+// ExportHoldings Index holdings in OnePlanet storage contracts (opluna and opust).
+func ExportHoldings(app *terra.TerraApp, bl util.Blacklist) (util.SnapshotBalanceAggregateMap, error) {
+	app.Logger().Info("Exporting OnePlanet")
+	var _ wasmtypes.QueryServer
+	ctx := util.PrepCtx(app)
+	q := util.PrepWasmQueryServer(app)
+
+	snapshot := make(util.SnapshotBalanceAggregateMap)
+
+	for _, contract := range []Contract{opUST, opLUNA} {
+		balances := make(util.BalanceMap)
+
+		err := util.GetCW20AccountsAndBalances(ctx, app.WasmKeeper, contract.Address, balances)
+		if err != nil {
+			return nil, err
+		}
+
+		for address, amount := range balances {
+			if amount.IsZero() {
+				continue
+			}
+
+			err, owner := getOwnerIfExists(ctx, q, address)
+			if err != nil {
+				// Not a contract, attribute funds to user wallet.
+				snapshot.AppendOrAddBalance(address, util.SnapshotBalance{
+					Denom:   contract.Denom,
+					Balance: amount,
+				})
+
+				continue
+			}
+
+			if owner == "" {
+				var salesInitMsg struct {
+					Config struct {
+						Recipient string `json:"recipient_wallet"`
+					} `json:"config"`
+				}
+				if err := util.ContractInitMsg(ctx, q, &wasmtypes.QueryContractInfoRequest{
+					ContractAddress: address,
+				}, &salesInitMsg); err != nil {
+					return nil, err
+				}
+
+				err, owner = getOwnerIfExists(ctx, q, salesInitMsg.Config.Recipient)
+				if err != nil {
+					owner = salesInitMsg.Config.Recipient
+				}
+			}
+
+			snapshot.AppendOrAddBalance(owner, util.SnapshotBalance{
+				Denom:   contract.Denom,
+				Balance: amount,
+			})
+		}
+	}
+
+	return snapshot, nil
+}
+
+func getOwnerIfExists(ctx context.Context, q wasmtypes.QueryServer, contractAddress string) (error, string) {
+	var initMsg struct {
+		Owner string `json:"owner"`
+	}
+
+	if err := util.ContractInitMsg(ctx, q, &wasmtypes.QueryContractInfoRequest{
+		ContractAddress: contractAddress,
+	}, &initMsg); err != nil {
+		return err, ""
+	}
+
+	return nil, initMsg.Owner
+}
+
+func Audit(app *terra.TerraApp, snapshot util.SnapshotBalanceAggregateMap) error {
+	app.Logger().Info("Audit -- OnePlanet")
+	ctx := util.PrepCtx(app)
+
+	ustBalance, err := util.GetNativeBalance(ctx, app.BankKeeper, util.DenomUST, opUST.Address)
+	if err != nil {
+		return err
+	}
+
+	if err := util.AlmostEqual(util.DenomUST, ustBalance, snapshot.SumOfDenom(util.DenomUST), sdk.NewInt(1000000)); err != nil {
+		return err
+	}
+
+	lunaBalance, err := util.GetNativeBalance(ctx, app.BankKeeper, util.DenomLUNA, opLUNA.Address)
+	if err != nil {
+		return err
+	}
+
+	if err := util.AlmostEqual(util.DenomLUNA, lunaBalance, snapshot.SumOfDenom(util.DenomLUNA), sdk.NewInt(1000000)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -157,7 +157,7 @@ func (k Keeper) GetContractInfo(ctx sdk.Context, contractAddress sdk.AccAddress)
 	store := ctx.KVStore(k.storeKey)
 	contractBz := store.Get(types.GetContractInfoKey(contractAddress))
 	if contractBz == nil {
-		return types.ContractInfo{}, sdkerrors.Wrapf(types.ErrNotFound, "constractInfo %s", contractAddress.String())
+		return types.ContractInfo{}, sdkerrors.Wrapf(types.ErrNotFound, "contractInfo %s", contractAddress.String())
 	}
 	k.cdc.MustUnmarshal(contractBz, &contractInfo)
 	return contractInfo, nil


### PR DESCRIPTION
## Summary of changes

The audit for this indexer matches up perfectly, 1 luna for every opluna, and 1 ust for every opust. 

Also fixed up a spelling mistake in `x/wasm/keeper/keeper.go`